### PR TITLE
Added ability to create one time token.

### DIFF
--- a/src/Endpoints/PaymentSource.php
+++ b/src/Endpoints/PaymentSource.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
  * @method string|null getToken()
  * @method string|null getType()
  * @method string|null getUpdatedAt()
+ * @method bool|null isOneTime()
  *
  * @DiscriminatorMap(typeProperty="type", mapping={
  *     "bank_account" = "EoneoPay\PhpSdk\Endpoints\PaymentSources\BankAccount",
@@ -34,12 +35,32 @@ class PaymentSource extends Entity implements PaymentSourceInterface
     use PaymentSourceTrait;
 
     /**
+     * Set if token to create should be one time.
+     *
+     * @var bool
+     */
+    private $isOneTime;
+
+    /**
+     * PaymentSource constructor.
+     *
+     * @param mixed[]|null $data
+     * @param bool|null $isOneTime
+     */
+    public function __construct(?array $data = null, ?bool $isOneTime = null)
+    {
+        $this->isOneTime = $isOneTime ?? false;
+
+        parent::__construct($data);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function uris(): array
     {
         return [
-            self::CREATE => '/tokens',
+            self::CREATE => \sprintf('/tokens%s', $this->isOneTime === true ? '/onetime' : ''),
             self::DELETE => \sprintf('/tokens/%s', $this->getToken()),
             self::GET => \sprintf('/tokens/%s', $this->getToken()),
         ];

--- a/src/Endpoints/PaymentSources/BankAccount.php
+++ b/src/Endpoints/PaymentSources/BankAccount.php
@@ -22,10 +22,11 @@ class BankAccount extends PaymentSource
      * Bank account constructor.
      *
      * @param mixed[]|null $data
+     * @param bool|null $isOneTime
      */
-    public function __construct(?array $data = null)
+    public function __construct(?array $data = null, ?bool $isOneTime = null)
     {
-        parent::__construct($data);
+        parent::__construct($data, $isOneTime);
 
         $this->type = self::SOURCE_BANK_ACCOUNT;
     }

--- a/src/Endpoints/PaymentSources/Bpay.php
+++ b/src/Endpoints/PaymentSources/Bpay.php
@@ -21,10 +21,11 @@ class Bpay extends PaymentSource
      * Bpay constructor.
      *
      * @param mixed[]|null $data
+     * @param bool|null $isOneTime
      */
-    public function __construct(?array $data = null)
+    public function __construct(?array $data = null, ?bool $isOneTime = null)
     {
-        parent::__construct($data);
+        parent::__construct($data, $isOneTime);
 
         $this->type = self::SOURCE_BPAY;
     }

--- a/src/Endpoints/PaymentSources/CreditCard.php
+++ b/src/Endpoints/PaymentSources/CreditCard.php
@@ -22,10 +22,11 @@ class CreditCard extends PaymentSource
      * Credit card constructor.
      *
      * @param mixed[]|null $data
+     * @param bool|null $isOneTime
      */
-    public function __construct(?array $data = null)
+    public function __construct(?array $data = null, ?bool $isOneTime = null)
     {
-        parent::__construct($data);
+        parent::__construct($data, $isOneTime);
 
         $this->type = self::SOURCE_CREDIT_CARD;
     }

--- a/src/Endpoints/PaymentSources/Ewallet.php
+++ b/src/Endpoints/PaymentSources/Ewallet.php
@@ -23,10 +23,11 @@ class Ewallet extends PaymentSource
      * Ewallet constructor.
      *
      * @param mixed[]|null $data
+     * @param bool|null $isOneTime
      */
-    public function __construct(?array $data = null)
+    public function __construct(?array $data = null, ?bool $isOneTime = null)
     {
-        parent::__construct($data);
+        parent::__construct($data, $isOneTime);
 
         $this->type = self::SOURCE_EWALLET;
     }

--- a/src/Factories/ExceptionFactory.php
+++ b/src/Factories/ExceptionFactory.php
@@ -78,7 +78,7 @@ final class ExceptionFactory implements ExceptionFactoryInterface
     /**
      * Get message.
      *
-     * @param $message
+     * @param mixed $message
      *
      * @return string|null
      */

--- a/src/Factories/ExceptionFactory.php
+++ b/src/Factories/ExceptionFactory.php
@@ -75,6 +75,13 @@ final class ExceptionFactory implements ExceptionFactoryInterface
         );
     }
 
+    /**
+     * Get message.
+     *
+     * @param $message
+     *
+     * @return string|null
+     */
     private function getMessage($message): ?string
     {
         if (\is_string($message)) {

--- a/src/Traits/PaymentSourceTrait.php
+++ b/src/Traits/PaymentSourceTrait.php
@@ -35,6 +35,13 @@ trait PaymentSourceTrait
     protected $name;
 
     /**
+     * Get if token is oneTime.
+     *
+     * @var bool|null
+     */
+    protected $oneTime;
+
+    /**
      * Payment source pan.
      *
      * @Assert\NotBlank()

--- a/tests/Endpoints/PaymentSources/OnetimeTokenTest.php
+++ b/tests/Endpoints/PaymentSources/OnetimeTokenTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\PhpSdk\Endpoints\PaymentSources;
+
+use EoneoPay\PhpSdk\Endpoints\V1\PaymentSources\BankAccount;
+use Tests\EoneoPay\PhpSdk\TestCase;
+
+/**
+ * @covers \EoneoPay\PhpSdk\Endpoints\PaymentSource
+ * @covers \EoneoPay\PhpSdk\Endpoints\V1\PaymentSources\BankAccount
+ */
+class OnetimeTokenTest extends TestCase
+{
+    /**
+     * Test one time token creation.
+     *
+     * @return void
+     *
+     * @throws \JsonException
+     */
+    public function testOneTimeTokenCreation(): void
+    {
+        $response = <<<JSON
+{
+    "country": "AU",
+    "created_at": "2020-05-08T02:35:42Z",
+    "currency": "AUD",
+    "id": "2b0068358e34a974e11094a4b32d9b08",
+    "name": "User Name",
+    "number": "987654321",
+    "one_time": true,
+    "pan": "123-456...4321",
+    "prefix": "123-456",
+    "token": "VC2ANGBD7XM6UTZPA327",
+    "type": "bank_account",
+    "updated_at": "2020-05-08T02:35:42Z",
+    "user": null
+}
+JSON;
+
+        $request = new BankAccount([
+            'country' => 'AU',
+            'name' => 'User Name',
+            'number' => '987654321',
+            'prefix' => '123456'
+        ], true);
+
+        /**
+         * @var \EoneoPay\PhpSdk\Endpoints\V1\PaymentSources\BankAccount $token
+         */
+        $token = $this->createApiManager(
+            \json_decode($response, true, 512, JSON_THROW_ON_ERROR)
+        )->create('user-api-key', $request);
+
+        // assert getters
+        self::assertSame('2b0068358e34a974e11094a4b32d9b08', $token->getId());
+        self::assertSame('2020-05-08T02:35:42Z', $token->getUpdatedAt());
+        self::assertSame('2020-05-08T02:35:42Z', $token->getCreatedAt());
+        self::assertSame('User Name', $token->getName());
+        self::assertSame('123-456...4321', $token->getPan());
+        self::assertSame('VC2ANGBD7XM6UTZPA327', $token->getToken());
+        self::assertSame('bank_account', $token->getType());
+        self::assertTrue($token->isOneTime());
+    }
+
+    /**
+     * Tests uris.
+     *
+     * @return void
+     */
+    public function testUris(): void
+    {
+        $token = new BankAccount([], true);
+
+        $expected = [
+            'create' => '/tokens/onetime',
+            'delete' => '/tokens/',
+            'get' => '/tokens/'
+        ];
+        self::assertSame($expected, $token->uris());
+    }
+}

--- a/tests/Endpoints/PaymentSources/OnetimeTokenTest.php
+++ b/tests/Endpoints/PaymentSources/OnetimeTokenTest.php
@@ -50,7 +50,7 @@ JSON;
          * @var \EoneoPay\PhpSdk\Endpoints\V1\PaymentSources\BankAccount $token
          */
         $token = $this->createApiManager(
-            \json_decode($response, true, 512, JSON_THROW_ON_ERROR)
+            \json_decode($response, true, 512, \JSON_THROW_ON_ERROR)
         )->create('user-api-key', $request);
 
         // assert getters

--- a/tests/Factories/ExceptionFactoryTest.php
+++ b/tests/Factories/ExceptionFactoryTest.php
@@ -25,10 +25,14 @@ final class ExceptionFactoryTest extends TestCase
      */
     public function getCreateData(): iterable
     {
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
-            'code' => 1999,
-            'message' => 'internal system error',
-        ]) ?: null));
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                \json_encode(['code' => 1999, 'message' => 'internal system error',]) ?: null
+            )
+        );
 
         yield 'critical exception' => [
             'responseException' => $responseException,

--- a/tests/Factories/ExceptionFactoryTest.php
+++ b/tests/Factories/ExceptionFactoryTest.php
@@ -22,15 +22,24 @@ final class ExceptionFactoryTest extends TestCase
      * Returns data for testCreate.
      *
      * @return mixed[]
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Long method required to define all scenarios.
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
+     * @throws \JsonException
      */
     public function getCreateData(): iterable
     {
+        $content = \json_encode(
+            ['code' => 1999, 'message' => 'internal system error',],
+            \JSON_THROW_ON_ERROR
+        ) ?: null;
         $responseException = new InvalidApiResponseException(
             new Response(
                 null,
                 null,
                 null,
-                \json_encode(['code' => 1999, 'message' => 'internal system error',]) ?: null
+                $content
             )
         );
 
@@ -45,11 +54,18 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
-            'code' => 1999,
-            'sub_code' => 2,
-            'message' => 'internal system error',
-        ]) ?: null));
+        $content = \json_encode(
+            ['code' => 1999, 'sub_code' => 2, 'message' => 'internal system error',],
+            \JSON_THROW_ON_ERROR
+        ) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'critical exception with sub code' => [
             'responseException' => $responseException,
@@ -62,11 +78,18 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
-            'code' => 6000,
-            'sub_code' => 1,
-            'message' => 'validation exception',
-        ]) ?: null));
+        $content = \json_encode(
+            ['code' => 6000, 'sub_code' => 1, 'message' => 'validation exception',],
+            \JSON_THROW_ON_ERROR
+        ) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'validation exception' => [
             'responseException' => $responseException,
@@ -80,11 +103,18 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
-            'code' => 5000,
-            'sub_code' => 3,
-            'message' => 'runtime exception',
-        ]) ?: null));
+        $content = \json_encode(
+            ['code' => 5000, 'sub_code' => 3, 'message' => 'runtime exception',],
+            \JSON_THROW_ON_ERROR
+        ) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'runtime exception' => [
             'responseException' => $responseException,
@@ -97,11 +127,18 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
-            'code' => 4000,
-            'sub_code' => 4,
-            'message' => 'client exception',
-        ]) ?: null));
+        $content = \json_encode(
+            ['code' => 4000, 'sub_code' => 4, 'message' => 'client exception',],
+            \JSON_THROW_ON_ERROR
+        ) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'client exception' => [
             'responseException' => $responseException,
@@ -114,11 +151,19 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
+        $content = \json_encode([
             'code' => 4000,
             'sub_code' => 4,
             'message' => ['message' => 'client exception'],
-        ]) ?: null));
+        ], \JSON_THROW_ON_ERROR) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'client exception' => [
             'responseException' => $responseException,
@@ -131,11 +176,19 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, \json_encode([
+        $content = \json_encode([
             'code' => 4000,
             'sub_code' => 4,
             'message' => ['not_message' => ['error' => ['message' => 'client exception']]],
-        ]) ?: null));
+        ], \JSON_THROW_ON_ERROR) ?: null;
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $content
+            )
+        );
 
         yield 'client exception' => [
             'responseException' => $responseException,
@@ -148,8 +201,15 @@ final class ExceptionFactoryTest extends TestCase
             ),
         ];
 
-        $rawContent = \json_encode(['code' => 4000, 'sub_code' => 4]);
-        $responseException = new InvalidApiResponseException(new Response(null, null, null, $rawContent ?: null));
+        $rawContent = \json_encode(['code' => 4000, 'sub_code' => 4], \JSON_THROW_ON_ERROR);
+        $responseException = new InvalidApiResponseException(
+            new Response(
+                null,
+                null,
+                null,
+                $rawContent ?: null
+            )
+        );
 
         yield 'client exception' => [
             'responseException' => $responseException,


### PR DESCRIPTION
This is a workaround to where you can't have multiple POST endpoints in an entity class due to design. So this adds an optional second parameter to payment source entities to set the token as one time token.